### PR TITLE
Native menu separator, kbd accelerators, fix indexing

### DIFF
--- a/src/menu/native.c
+++ b/src/menu/native.c
@@ -155,7 +155,7 @@ static bool add_menu(MENU * mp, MENU * parent, int parent_pos)
 		if(parent->text)
 		{
 			al_append_menu_item(native_menu[parent_pos], get_menu_text(parent->text, buf), current_id, flags, NULL, native_menu[this_menu]);
-			index_a4_menu_item(current_id, mp);
+			index_a4_menu_item(current_id, parent);
 			native_menu_items[parent_pos]++;
 			current_id++;
 		}

--- a/src/menu/native.c
+++ b/src/menu/native.c
@@ -113,9 +113,8 @@ static bool add_menu(MENU * mp, MENU * parent, int parent_pos)
 				return false;
 			}
 		}
-
 		/* Add menu item to current menu. */
-		else
+		else if (mp->proc)
 		{
 			flags = 0;
 			if(mp->flags & D_SELECTED)
@@ -135,6 +134,9 @@ static bool add_menu(MENU * mp, MENU * parent, int parent_pos)
 			native_menu_items[this_menu]++;
 			current_id++;
 		}
+		else /* A separator */
+			al_append_menu_item(native_menu[this_menu], NULL, 0, 0, NULL, NULL);
+
 		mp++;
 	}
 

--- a/src/menu/native.c
+++ b/src/menu/native.c
@@ -86,7 +86,6 @@ static bool update_a4_menu_item(int id, const char * caption, int flags)
 
 static bool add_menu(MENU * mp, MENU * parent, int parent_pos)
 {
-	char buf[256];
 	int flags;
 	int this_menu = current_menu;
 
@@ -129,7 +128,7 @@ static bool add_menu(MENU * mp, MENU * parent, int parent_pos)
 			{
 				flags |= ALLEGRO_MENU_ITEM_CHECKBOX;
 			}
-			al_append_menu_item(native_menu[this_menu], mp->proc ? get_menu_text(mp->text, buf) : "", current_id, flags, NULL, NULL);
+			al_append_menu_item(native_menu[this_menu], mp->text, current_id, flags, NULL, NULL);
 			index_a4_menu_item(current_id, mp);
 			native_menu_items[this_menu]++;
 			current_id++;
@@ -154,7 +153,7 @@ static bool add_menu(MENU * mp, MENU * parent, int parent_pos)
 		}
 		if(parent->text)
 		{
-			al_append_menu_item(native_menu[parent_pos], get_menu_text(parent->text, buf), current_id, flags, NULL, native_menu[this_menu]);
+			al_append_menu_item(native_menu[parent_pos], parent->text, current_id, flags, NULL, native_menu[this_menu]);
 			index_a4_menu_item(current_id, parent);
 			native_menu_items[parent_pos]++;
 			current_id++;


### PR DESCRIPTION
* Typo in parent menu creation caused improper indexing
* Use proper menu separator
* Show keyboard accelerators